### PR TITLE
Added textTheme used for the risk card in the Banque Stage's app SST section

### DIFF
--- a/lib/crcrme_material_theme.dart
+++ b/lib/crcrme_material_theme.dart
@@ -95,5 +95,15 @@ ThemeData get crcrmeMaterialTheme {
             elevation: MaterialStateProperty.all(0))),
     floatingActionButtonTheme:
         const FloatingActionButtonThemeData(foregroundColor: white),
-  );
+        textTheme: const TextTheme(
+          titleLarge: TextStyle(color: Colors.blue),
+          headlineMedium: TextStyle(
+              color: Color.fromARGB(255, 1, 1, 1),
+              fontWeight: FontWeight.bold,
+              fontSize: 20),
+          headlineSmall: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Color.fromARGB(255, 190, 77, 81),
+              fontSize: 16)));
+  
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cr-crme/crcrme_material_theme/6)
<!-- Reviewable:end -->
